### PR TITLE
Added ability to skip intro that "everyone saw 25 years ago."

### DIFF
--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -1356,7 +1356,7 @@ s32 init_level(void) {
                 if (gMarioState->action != ACT_UNINITIALIZED) {
                     if (save_file_exists(gCurrSaveFileNum - 1)) {
                         set_mario_action(gMarioState, ACT_IDLE, 0);
-                    } else if (gCLIOpts.SkipIntro == 0 && configSkipIntro == 0) {
+                    } else if (gCLIOpts.SkipIntro == 0 && configSkipIntro == 0 && gServerSettings.skipIntro == NO_SKIP) {
                         set_mario_action(gMarioState, ACT_INTRO_CUTSCENE, 0);
                         val4 = 1;
                     }

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -1356,7 +1356,7 @@ s32 init_level(void) {
                 if (gMarioState->action != ACT_UNINITIALIZED) {
                     if (save_file_exists(gCurrSaveFileNum - 1)) {
                         set_mario_action(gMarioState, ACT_IDLE, 0);
-                    } else if (gCLIOpts.SkipIntro == 0 && configSkipIntro == 0 && gServerSettings.skipIntro == NO_SKIP) {
+                    } else if (gCLIOpts.SkipIntro == 0 && configSkipIntro == 0 && gServerSettings.skipIntro == 0) {
                         set_mario_action(gMarioState, ACT_INTRO_CUTSCENE, 0);
                         val4 = 1;
                     }

--- a/src/menu/custom_menu.c
+++ b/src/menu/custom_menu.c
@@ -42,7 +42,7 @@ static void menu_main_draw_strings(void) {
 
 static void host_menu_draw_strings(void) {
     #ifdef DISCORD_SDK
-        #define HOST_MENU_MAX_ITEMS 5
+        #define HOST_MENU_MAX_ITEMS 4
     #else
         #define HOST_MENU_MAX_ITEMS 3
     #endif

--- a/src/menu/custom_menu.c
+++ b/src/menu/custom_menu.c
@@ -41,7 +41,7 @@ static void menu_main_draw_strings(void) {
 
 static void host_menu_draw_strings(void) {
     #ifdef DISCORD_SDK
-        #define HOST_MENU_MAX_ITEMS 4
+        #define HOST_MENU_MAX_ITEMS 5
     #else
         #define HOST_MENU_MAX_ITEMS 3
     #endif
@@ -64,9 +64,11 @@ static void host_menu_draw_strings(void) {
     }
 
     buttonText[2] = configStayInLevelAfterStar ? "Stay in level after star." : "Leave level after star.";
+    
+    buttonText[3] = configIntroSkip ? "Play intro cutscene." : "Skip intro cutscene.";
 
     #ifdef DISCORD_SDK
-        buttonText[3] = (configNetworkSystem == 0) ? "Host through Discord." : "Host direct connection.";
+        buttonText[4] = (configNetworkSystem == 0) ? "Host through Discord." : "Host direct connection.";
     #endif
 
     // display server setting strings
@@ -126,6 +128,10 @@ static void host_menu_setting_knockback(void) {
 
 static void host_menu_setting_stay_in_level(void) {
     configStayInLevelAfterStar = (configStayInLevelAfterStar == 0) ? 1 : 0;
+}
+
+static void host_menu_setting_skip_intro(void) {
+    configSkipIntro = (configSkipIntro == 0) ? 1 : 0;
 }
 
 #ifdef DISCORD_SDK
@@ -241,6 +247,7 @@ void custom_menu_init(struct CustomMenu* head) {
     hostMenu->draw_strings = host_menu_draw_strings;
     custom_menu_create_button(hostMenu, "CANCEL", 700, -400 + (250 * 3), SOUND_MENU_CAMERA_ZOOM_OUT, custom_menu_close);
     custom_menu_create_button(hostMenu, "HOST", 700, -400, SOUND_MENU_CAMERA_ZOOM_IN, host_menu_do_host);
+    custom_menu_create_button(hostMenu, "", -700, -400 + (250 * 4), SOUND_ACTION_BONK, host_menu_setting_skip_intro);
     custom_menu_create_button(hostMenu, "", -700, -400 + (250 * 3), SOUND_ACTION_BONK, host_menu_setting_interaction);
     custom_menu_create_button(hostMenu, "", -700, -400 + (250 * 2), SOUND_ACTION_BONK, host_menu_setting_knockback);
     custom_menu_create_button(hostMenu, "", -700, -400 + (250 * 1), SOUND_ACTION_BONK, host_menu_setting_stay_in_level);

--- a/src/menu/custom_menu.c
+++ b/src/menu/custom_menu.c
@@ -42,9 +42,9 @@ static void menu_main_draw_strings(void) {
 
 static void host_menu_draw_strings(void) {
     #ifdef DISCORD_SDK
-        #define HOST_MENU_MAX_ITEMS 4
+        #define HOST_MENU_MAX_ITEMS 5
     #else
-        #define HOST_MENU_MAX_ITEMS 3
+        #define HOST_MENU_MAX_ITEMS 4
     #endif
 
     // set up server setting strings

--- a/src/menu/custom_menu.c
+++ b/src/menu/custom_menu.c
@@ -257,7 +257,7 @@ void custom_menu_init(struct CustomMenu* head) {
     #endif
 
     #ifdef DISCORD_SDK
-        struct CustomMenu* joinMenu = custom_menu_create(head, "JOIN", 266, 0, gButtonScale.small);
+        struct CustomMenu* joinMenu = custom_menu_create(head, "JOIN", 266, 0, gButtonScale.large);
         custom_menu_create_button(joinMenu, "CANCEL", -266, -320, gButtonScale.large, SOUND_MENU_CAMERA_ZOOM_OUT, custom_menu_close);
         joinMenu->draw_strings = join_menu_draw_strings;
         struct CustomMenu* connectMenu = custom_menu_create(joinMenu, "CONNECT", 266, -320, gButtonScale.large);

--- a/src/menu/custom_menu.c
+++ b/src/menu/custom_menu.c
@@ -25,6 +25,7 @@
 char sConnectionJoinError[128] = { 0 };
 char gConnectionText[128] = { 0 };
 struct CustomMenu* sConnectMenu = NULL;
+
 u8 gOpenConnectMenu = FALSE;
 s8 sGotoGame = 0;
 
@@ -64,8 +65,8 @@ static void host_menu_draw_strings(void) {
     }
 
     buttonText[2] = configStayInLevelAfterStar ? "Stay in level after star." : "Leave level after star.";
-    
-    buttonText[3] = configIntroSkip ? "Play intro cutscene." : "Skip intro cutscene.";
+
+    buttonText[3] = configSkipIntro ? "Skip intro cutscene." : "Play intro cutscene.";
 
     #ifdef DISCORD_SDK
         buttonText[4] = (configNetworkSystem == 0) ? "Host through Discord." : "Host direct connection.";
@@ -73,17 +74,17 @@ static void host_menu_draw_strings(void) {
 
     // display server setting strings
     for (int i = 0; i < HOST_MENU_MAX_ITEMS; i++) {
-        print_generic_ascii_string(95, 158 + -35 * i, buttonText[i]);
+        print_generic_ascii_string(95, 181 + -33.5 * i, buttonText[i]);
     }
 
     // display direct connection warning
     if (configNetworkSystem != 0) {
-        print_generic_ascii_string(0, 30, "For direct connections -");
+        print_generic_ascii_string(0, 20, "For direct connections -");
         f32 red = (f32)fabs(sin(gGlobalTimer / 20.0f));
         gDPSetEnvColor(gDisplayListHead++, 222, 222 * red, 222 * red, gMenuStringAlpha);
         char warning[128];
         snprintf(warning, 127, "You must forward port '%d' in your router or use Hamachi.", configHostPort);
-        print_generic_ascii_string(0, 15, warning);
+        print_generic_ascii_string(0, 5, warning);
 
     }
 }
@@ -131,7 +132,7 @@ static void host_menu_setting_stay_in_level(void) {
 }
 
 static void host_menu_setting_skip_intro(void) {
-    configSkipIntro = (configSkipIntro == 0) ? 1 : 0;
+    configSkipIntro = (configSkipIntro == 1) ? 0 : 1;
 }
 
 #ifdef DISCORD_SDK
@@ -217,7 +218,7 @@ static void connect_menu_on_click(void) {
 
     // fill in our last attempt
     if (configJoinPort == 0 || configJoinPort > 65535) { configJoinPort = DEFAULT_PORT; }
-    
+
     // only print custom port
     if (configJoinPort == DEFAULT_PORT) {
         sprintf(gTextInput, "%s", configJoinIp);
@@ -243,30 +244,30 @@ void custom_menu_init(struct CustomMenu* head) {
     head->draw_strings = menu_main_draw_strings;
 
     // create sub menus and buttons
-    struct CustomMenu* hostMenu = custom_menu_create(head, "HOST", -266, 0);
+    struct CustomMenu* hostMenu = custom_menu_create(head, "HOST", -266, 20, gButtonScale.large);
     hostMenu->draw_strings = host_menu_draw_strings;
-    custom_menu_create_button(hostMenu, "CANCEL", 700, -400 + (250 * 3), SOUND_MENU_CAMERA_ZOOM_OUT, custom_menu_close);
-    custom_menu_create_button(hostMenu, "HOST", 700, -400, SOUND_MENU_CAMERA_ZOOM_IN, host_menu_do_host);
-    custom_menu_create_button(hostMenu, "", -700, -400 + (250 * 4), SOUND_ACTION_BONK, host_menu_setting_skip_intro);
-    custom_menu_create_button(hostMenu, "", -700, -400 + (250 * 3), SOUND_ACTION_BONK, host_menu_setting_interaction);
-    custom_menu_create_button(hostMenu, "", -700, -400 + (250 * 2), SOUND_ACTION_BONK, host_menu_setting_knockback);
-    custom_menu_create_button(hostMenu, "", -700, -400 + (250 * 1), SOUND_ACTION_BONK, host_menu_setting_stay_in_level);
+    custom_menu_create_button(hostMenu, "CANCEL", 700, -237 + (240 * 3), gButtonScale.large, SOUND_MENU_CAMERA_ZOOM_OUT, custom_menu_close);
+    custom_menu_create_button(hostMenu, "HOST", 700, -290, gButtonScale.large, SOUND_MENU_CAMERA_ZOOM_IN, host_menu_do_host);
+    custom_menu_create_button(hostMenu, "", -700, -220 + (240 * 3), gButtonScale.medium, SOUND_ACTION_BONK, host_menu_setting_interaction);
+    custom_menu_create_button(hostMenu, "", -700, -220 + (240 * 2), gButtonScale.medium, SOUND_ACTION_BONK, host_menu_setting_knockback);
+    custom_menu_create_button(hostMenu, "", -700, -220 + (240 * 1), gButtonScale.medium, SOUND_ACTION_BONK, host_menu_setting_stay_in_level);
+        custom_menu_create_button(hostMenu, "", -700, -220 + (240 * 0), gButtonScale.medium, SOUND_ACTION_BONK, host_menu_setting_skip_intro);
     #ifdef DISCORD_SDK
-        custom_menu_create_button(hostMenu, "", -700, -400 + (250 * 0), SOUND_ACTION_BONK, host_menu_setting_network_system);
+        custom_menu_create_button(hostMenu, "", -700, -220 + (240 * -1), gButtonScale.medium, SOUND_ACTION_BONK, host_menu_setting_network_system);
     #endif
 
     #ifdef DISCORD_SDK
-        struct CustomMenu* joinMenu = custom_menu_create(head, "JOIN", 266, 0);
-        custom_menu_create_button(joinMenu, "CANCEL", -266, -320, SOUND_MENU_CAMERA_ZOOM_OUT, custom_menu_close);
+        struct CustomMenu* joinMenu = custom_menu_create(head, "JOIN", 266, 0, gButtonScale.small);
+        custom_menu_create_button(joinMenu, "CANCEL", -266, -320, gButtonScale.large, SOUND_MENU_CAMERA_ZOOM_OUT, custom_menu_close);
         joinMenu->draw_strings = join_menu_draw_strings;
-        struct CustomMenu* connectMenu = custom_menu_create(joinMenu, "CONNECT", 266, -320);
+        struct CustomMenu* connectMenu = custom_menu_create(joinMenu, "CONNECT", 266, -320, gButtonScale.large);
     #else
-        struct CustomMenu* connectMenu = custom_menu_create(head, "CONNECT", 266, 0);
+        struct CustomMenu* connectMenu = custom_menu_create(head, "CONNECT", 266, 0, gButtonScale.large);
     #endif
     connectMenu->me->on_click = connect_menu_on_click;
     connectMenu->on_close = connect_menu_on_close;
     connectMenu->draw_strings = connect_menu_draw_strings;
-    custom_menu_create_button(connectMenu, "CANCEL", 0, -400, SOUND_MENU_CAMERA_ZOOM_OUT, custom_menu_close);
+    custom_menu_create_button(connectMenu, "CANCEL", 0, -400, gButtonScale.large, SOUND_MENU_CAMERA_ZOOM_OUT, custom_menu_close);
     sConnectMenu = connectMenu;
 }
 

--- a/src/menu/custom_menu_system.c
+++ b/src/menu/custom_menu_system.c
@@ -22,12 +22,21 @@
 static struct CustomMenu* sHead = NULL;
 static struct CustomMenu* sCurrentMenu = NULL;
 static struct CustomMenu* sLastMenu = NULL;
+struct CustomMenuButtonScale gButtonScale = {
+    .small = 0.08111111f,
+    .medium = 0.09511111f,
+    .large = 0.11111111f,
+};
+
+//buttonScale.SMALL = 0.08111111f;
+//buttonScale.MEDIUM = 0.09511111f;
+//buttonScale.LARGE = 0.11111111f;
 
 u8 gMenuStringAlpha = 255;
 static u8 sErrorDialog[MAX_ERROR_MESSAGE_LENGTH] = { 0 };
 static u8 sErrorDialogShow = FALSE;
 
-struct CustomMenuButton* custom_menu_create_button(struct CustomMenu* parent, char* label, u16 x, u16 y, s32 clickSound, void (*on_click)(void)) {
+struct CustomMenuButton* custom_menu_create_button(struct CustomMenu* parent, char* label, u16 x, u16 y, f32 scale, s32 clickSound, void (*on_click)(void)) {
     struct CustomMenuButton* button = calloc(1, sizeof(struct CustomMenuButton));
     if (parent->buttons == NULL) {
         parent->buttons = button;
@@ -43,7 +52,8 @@ struct CustomMenuButton* custom_menu_create_button(struct CustomMenu* parent, ch
     button->clickSound = clickSound;
 
     struct Object* obj = spawn_object_rel_with_rot(parent->me->object, MODEL_MAIN_MENU_MARIO_NEW_BUTTON, bhvMenuButton, x * -1, y, -1, 0, 0x8000, 0);
-    obj->oMenuButtonScale = 0.11111111f;
+
+    obj->oMenuButtonScale = scale;
     obj->oFaceAngleRoll = 0;
     obj->oMenuButtonTimer = 0;
     obj->oMenuButtonOrigPosX = obj->oParentRelativePosX;
@@ -55,8 +65,8 @@ struct CustomMenuButton* custom_menu_create_button(struct CustomMenu* parent, ch
     return button;
 }
 
-struct CustomMenu* custom_menu_create(struct CustomMenu* parent, char* label, u16 x, u16 y) {
-    struct CustomMenuButton* button = custom_menu_create_button(parent, label, x, y, SOUND_MENU_CAMERA_ZOOM_IN, NULL);
+struct CustomMenu* custom_menu_create(struct CustomMenu* parent, char* label, u16 x, u16 y, f32 scale) {
+    struct CustomMenuButton* button = custom_menu_create_button(parent, label, x, y, scale, SOUND_MENU_CAMERA_ZOOM_IN, NULL);
     struct CustomMenu* menu = calloc(1, sizeof(struct CustomMenu));
     menu->parent = parent;
     menu->depth = parent->depth + 1;
@@ -182,13 +192,15 @@ void custom_menu_close_system(void) {
 static s32 cursor_inside_button(struct CustomMenuButton* button, f32 cursorX, f32 cursorY) {
     f32 x = button->object->oParentRelativePosX;
     f32 y = button->object->oParentRelativePosY;
+    f32 scale = button->object->oMenuButtonScale;
+
     x *= -0.137f;
     y *= 0.137f;
 
-    s16 maxX = x + 25.0f;
-    s16 minX = x - 25.0f;
-    s16 maxY = y + 21.0f;
-    s16 minY = y - 21.0f;
+    s16 maxX = x + scale * 185.0f;
+    s16 minX = x - scale * 185.0f;
+    s16 maxY = y + scale * 185.0f;
+    s16 minY = y - scale * 101.0f;
 
     return (cursorX < maxX && minX < cursorX && cursorY < maxY && minY < cursorY);
 }
@@ -229,7 +241,7 @@ void custom_menu_cursor_click(f32 cursorX, f32 cursorY) {
             }
 
             if (didSomething) { break; }
-        } 
+        }
         button = button->next;
     }
 }
@@ -247,7 +259,7 @@ void custom_menu_print_strings(void) {
     // figure out alpha
     struct Object* curObj = sCurrentMenu->me->object;
     struct Object* lastObj = (sLastMenu != NULL) ? sLastMenu->me->object : NULL;
-    
+
     if (curObj != NULL && lastObj != NULL) {
         if (curObj->oMenuButtonState == MENU_BUTTON_STATE_FULLSCREEN && lastObj->oMenuButtonState != MENU_BUTTON_STATE_SHRINKING) {
             if (gMenuStringAlpha < 250) {

--- a/src/menu/custom_menu_system.h
+++ b/src/menu/custom_menu_system.h
@@ -21,11 +21,18 @@ struct CustomMenu {
     void (*on_close)(void);
 };
 
+struct CustomMenuButtonScale {
+    f32 small;
+    f32 medium;
+    f32 large;
+};
+extern struct CustomMenuButtonScale gButtonScale;
+
 extern u8 gMenuStringAlpha;
 
 void custom_menu_system_init(void);
-struct CustomMenu* custom_menu_create(struct CustomMenu* parent, char* label, u16 x, u16 y);
-struct CustomMenuButton* custom_menu_create_button(struct CustomMenu* parent, char* label, u16 x, u16 y, s32 clickSound, void (*on_click)(void));
+struct CustomMenu* custom_menu_create(struct CustomMenu* parent, char* label, u16 x, u16 y, f32 scale);
+struct CustomMenuButton* custom_menu_create_button(struct CustomMenu* parent, char* label, u16 x, u16 y, f32 scale, s32 clickSound, void (*on_click)(void));
 
 void custom_menu_system_loop(void);
 void custom_menu_print_strings(void);

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -52,6 +52,7 @@ bool network_init(enum NetworkType inNetworkType) {
     gServerSettings.playerInteractions = configPlayerInteraction;
     gServerSettings.playerKnockbackStrength = configPlayerKnockbackStrength;
     gServerSettings.stayInLevelAfterStar = configStayInLevelAfterStar;
+    gServerSettings.skipIntro = configSkipIntro;
 
     // initialize the network system
     int rc = gNetworkSystem->initialize(inNetworkType);

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -28,6 +28,7 @@ struct StringLinkedList gRegisteredMods = { 0 };
 struct ServerSettings gServerSettings = {
     .playerInteractions = PLAYER_INTERACTIONS_SOLID,
     .playerKnockbackStrength = 25,
+    .skipIntro = SKIP_INTRO,
 };
 
 void network_set_system(enum NetworkSystemType nsType) {
@@ -51,6 +52,7 @@ bool network_init(enum NetworkType inNetworkType) {
     gServerSettings.playerInteractions = configPlayerInteraction;
     gServerSettings.playerKnockbackStrength = configPlayerKnockbackStrength;
     gServerSettings.stayInLevelAfterStar = configStayInLevelAfterStar;
+    gServerSettings.skipIntro = skipIntro;
 
     // initialize the network system
     int rc = gNetworkSystem->initialize(inNetworkType);

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -27,7 +27,7 @@ struct StringLinkedList gRegisteredMods = { 0 };
 
 struct ServerSettings gServerSettings = {
     .playerInteractions = PLAYER_INTERACTIONS_SOLID,
-    .skipIntro = NO_SKIP,
+    .skipIntro = 0,
     .playerKnockbackStrength = 25,
 };
 

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -27,8 +27,8 @@ struct StringLinkedList gRegisteredMods = { 0 };
 
 struct ServerSettings gServerSettings = {
     .playerInteractions = PLAYER_INTERACTIONS_SOLID,
+    .skipIntro = NO_SKIP,
     .playerKnockbackStrength = 25,
-    .skipIntro = SKIP_INTRO,
 };
 
 void network_set_system(enum NetworkSystemType nsType) {
@@ -52,7 +52,6 @@ bool network_init(enum NetworkType inNetworkType) {
     gServerSettings.playerInteractions = configPlayerInteraction;
     gServerSettings.playerKnockbackStrength = configPlayerKnockbackStrength;
     gServerSettings.stayInLevelAfterStar = configStayInLevelAfterStar;
-    gServerSettings.skipIntro = skipIntro;
 
     // initialize the network system
     int rc = gNetworkSystem->initialize(inNetworkType);

--- a/src/pc/network/network.h
+++ b/src/pc/network/network.h
@@ -70,8 +70,14 @@ enum PlayerInteractions {
     PLAYER_INTERACTIONS_PVP,
 };
 
+enum IntroSkip {
+    SKIP,
+    NO_SKIP,
+};
+
 struct ServerSettings {
     enum PlayerInteractions playerInteractions;
+    enum IntroSkip introSkip;
     u8 playerKnockbackStrength;
     u8 stayInLevelAfterStar;
 };

--- a/src/pc/network/network.h
+++ b/src/pc/network/network.h
@@ -70,16 +70,11 @@ enum PlayerInteractions {
     PLAYER_INTERACTIONS_PVP,
 };
 
-enum IntroSkip {
-    SKIP,
-    NO_SKIP,
-};
-
 struct ServerSettings {
     enum PlayerInteractions playerInteractions;
-    enum IntroSkip introSkip;
     u8 playerKnockbackStrength;
     u8 stayInLevelAfterStar;
+    u8 skipIntro;
 };
 
 // Networking-specific externs

--- a/src/pc/network/packets/packet_join.c
+++ b/src/pc/network/packets/packet_join.c
@@ -61,6 +61,7 @@ void network_send_join(struct Packet* joinRequestPacket) {
     packet_write(&p, &gServerSettings.playerInteractions, sizeof(u8));
     packet_write(&p, &gServerSettings.playerKnockbackStrength, sizeof(u8));
     packet_write(&p, &gServerSettings.stayInLevelAfterStar, sizeof(u8));
+    packet_write(&p, &gServerSettings.skipIntro, sizeof(u8));
     packet_write(&p, eeprom, sizeof(u8) * 512);
 
     u8 modCount = string_linked_list_count(&gRegisteredMods);
@@ -124,6 +125,7 @@ void network_receive_join(struct Packet* p) {
     packet_read(p, &gServerSettings.playerInteractions, sizeof(u8));
     packet_read(p, &gServerSettings.playerKnockbackStrength, sizeof(u8));
     packet_read(p, &gServerSettings.stayInLevelAfterStar, sizeof(u8));
+    packet_read(p, &gServerSettings.skipIntro, sizeof(u8));
     packet_read(p, eeprom, sizeof(u8) * 512);
     packet_read(p, &modCount, sizeof(u8));
 


### PR DESCRIPTION
Buttons are now resizeable. Use `gButtonScale.<size>` (large, medium, or small).
It could be argued that we don't need the `small` size. However, it may be beneficial for the future if the menu becomes more complex.

large is the normal default size. Or at least it was the size already being used by sm64ex-coop (`0.11111111f`)

Note: Buttons for changing menu's should be gButtonScale.large as the menu animation is made for large buttons. To keep consistency it's probably a good idea for buttons that transfer you to a new menu to always be set to large. As such, I didn't feel it necessary to extend this feature to these methods: `bhv_menu_button_growing_from_custom` and `bhv_menu_button_shrinking_to_custom`.  

Please download this build from my branch and test it for any bugs or synchronization issues.

Resolves #60 