### PR TITLE
Added connection transition and free'd menu calloc

### DIFF
--- a/src/menu/custom_menu.c
+++ b/src/menu/custom_menu.c
@@ -286,7 +286,11 @@ void custom_menu_init(struct CustomMenu* head) {
 
 void custom_menu_loop(void) {
     // we've received an event that makes us exit the menus
-    if (sGotoGame) { sSelectedFileNum = sGotoGame; }
+    if (sGotoGame) {
+        sSelectedFileNum = sGotoGame;
+        custom_menu_close_system();
+        custom_menu_destroy();
+    }
 
     // force-start the load when command-line server hosting
     if (gNetworkType == NT_SERVER && sSelectedFileNum == 0) {

--- a/src/menu/custom_menu_system.c
+++ b/src/menu/custom_menu_system.c
@@ -96,7 +96,7 @@ void custom_menu_system_init(void) {
 }
 
 void custom_menu_destroy(void) {
-    free(sHead);
+    //  TODO: clean up all of the calloc()'d memory
     sHead = NULL;
     sCurrentMenu = NULL;
     sLastMenu = NULL;

--- a/src/menu/custom_menu_system.c
+++ b/src/menu/custom_menu_system.c
@@ -96,7 +96,11 @@ void custom_menu_system_init(void) {
 }
 
 void custom_menu_destroy(void) {
-    /* TODO: we should probably clean up all of this stuff */
+    free(sHead);
+    sHead = NULL;
+    sCurrentMenu = NULL;
+    sLastMenu = NULL;
+    overlay = NULL;
 }
 
 void custom_menu_system_loop(void) {


### PR DESCRIPTION
A more desirable feature would be that a background stays up while the client connects to the host. However, due to a difficulty in figuring out why the custom menu closes when a player connects I compromised for freeing the menu calloc and trying to clean-up the visible jumbled UI.