### PR TITLE
Allow binding to ports <1024 on non-linux builds

### DIFF
--- a/src/pc/djui/djui_panel_host.c
+++ b/src/pc/djui/djui_panel_host.c
@@ -27,7 +27,11 @@ static bool djui_panel_host_port_valid(void) {
         port += (*buffer - '0');
         buffer++;
     }
+#if __linux__
     return port >= 1024 && port <= 65535;
+#else
+    return port <= 65535;
+#endif
 }
 
 static void djui_panel_host_port_text_change(struct DjuiBase* caller) {

--- a/src/pc/djui/djui_panel_join.c
+++ b/src/pc/djui/djui_panel_join.c
@@ -52,13 +52,13 @@ static bool djui_panel_join_ip_parse_spacer(char** msg) {
 }
 
 static bool djui_panel_join_ip_parse_port(char** msg) {
-    int num = 0;
+    int port = 0;
     for (int i = 0; i < 5; i++) {
         char c = **msg;
         if (c >= '0' && c <= '9') {
             // is number
-            num *= 10;
-            num += (c - '0');
+            port *= 10;
+            port += (c - '0');
             *msg = *msg + 1;
         } else if (i == 0) {
             return false;
@@ -67,7 +67,7 @@ static bool djui_panel_join_ip_parse_port(char** msg) {
         }
     }
 
-    return num >= 1024 && num <= 65535;
+    return port <= 65535;
 }
 
 static bool djui_panel_join_ip_valid(char* buffer) {


### PR DESCRIPTION
This seems to be only a restriction on Linux, and Mac versions older then Mojave